### PR TITLE
Fix header to be the old version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,18 +9,12 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <title>Course Materials Assistant</title>
+    <title>Course Assistant</title>
     <link rel="stylesheet" href="style.css?v=10" />
   </head>
   <body>
     <div class="container">
       <header>
-        <div class="header-content">
-          <h1>Course Materials Assistant</h1>
-          <p class="subtitle">
-            Ask questions about courses, instructors, and content
-          </p>
-        </div>
         <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
           <span class="theme-icon sun-icon">☀️</span>
           <span class="theme-icon moon-icon">🌙</span>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -74,30 +74,15 @@ body {
 
 /* Header */
 header {
-  padding: 1.5rem 2rem;
+  padding: 1rem 2rem;
   background: var(--surface);
   border-bottom: 1px solid var(--border-color);
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
 }
 
-header h1 {
-  font-size: 1.75rem;
-  font-weight: 700;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  margin: 0;
-}
-
-.subtitle {
-  font-size: 0.95rem;
-  color: var(--text-secondary);
-  margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {
@@ -162,11 +147,6 @@ header h1 {
     transform: rotate(90deg) scale(0.8);
 }
 
-/* Header content wrapper for better layout */
-.header-content {
-    display: flex;
-    flex-direction: column;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {


### PR DESCRIPTION
Reverted header to simpler version as requested in issue #2

Changes:
- Removed "Course Materials Assistant" header text
- Removed subheader about asking questions
- Removed header content wrapper div
- Kept theme toggle functionality intact
- Updated page title to be more generic
- Adjusted header CSS for better layout

Closes #2

Generated with [Claude Code](https://claude.ai/code)